### PR TITLE
Fix dark mode

### DIFF
--- a/src/components/AccountMenu.svelte
+++ b/src/components/AccountMenu.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { showLoginDialog } from './Dialogs.svelte';
-  import { account } from '../models/account.svelte.js';
-  import { settings } from '../models/settings.svelte.js';
-  import { getBaseLocation } from '../router.js';
-  import AccountMenuButton from './AccountMenuButton.svelte';
-  import LoadableImage from './LoadableImage.svelte';
+  import { showLoginDialog } from "./Dialogs.svelte";
+  import { account } from "../models/account.svelte.js";
+  import { settings } from "../models/settings.svelte.js";
+  import { getBaseLocation } from "../router.js";
+  import AccountMenuButton from "./AccountMenuButton.svelte";
+  import LoadableImage from "./LoadableImage.svelte";
 
   let menuVisible = $state(false);
 
   $effect(() => {
-    let html = document.body.parentNode!
-    html.addEventListener('click', hideMenu);
+    let html = document.body.parentNode!;
+    html.addEventListener("click", hideMenu);
 
     return () => {
-      html.removeEventListener('click', hideMenu);
+      html.removeEventListener("click", hideMenu);
     };
   });
 
@@ -57,10 +57,8 @@
 <div id="account" onclick={toggleMenu} class={{ active: menuVisible }}>
   {#if account.isIncognito}
     <i class="fa-solid fa-user-secret fa-lg"></i>
-
   {:else if !account.loggedIn || account.avatarIsLoading}
     <i class="fa-regular fa-user-circle fa-xl"></i>
-
   {:else if account.loggedIn && account.avatarURL}
     <LoadableImage class="avatar" src={account.avatarURL}>
       {#snippet loading()}
@@ -70,13 +68,16 @@
         <i class="fa-solid fa-user-circle fa-xl"></i>
       {/snippet}
     </LoadableImage>
-
   {:else}
     <i class="fa-solid fa-user-circle fa-xl"></i>
   {/if}
 </div>
 
-<div id="account_menu" style="visibility: {menuVisible ? 'visible' : 'hidden'}" onclick={(e) => e.stopPropagation()}>
+<div
+  id="account_menu"
+  style="visibility: {menuVisible ? 'visible' : 'hidden'}"
+  onclick={(e) => e.stopPropagation()}
+>
   <ul>
     {#if account.loggedIn}
       <AccountMenuButton
@@ -100,7 +101,7 @@
       <AccountMenuButton onclick={logOut} label="Log out" />
     {/if}
 
-    <li class="link"><a href="{getBaseLocation()}">Home</a></li>
+    <li class="link"><a href={getBaseLocation()}>Home</a></li>
     <li class="link"><a href="?page=posting_stats">Posting stats</a></li>
     <li class="link"><a href="?page=like_stats">Like stats</a></li>
     <li class="link"><a href="?page=search">Timeline search</a></li>
@@ -142,7 +143,7 @@
     left: 5px;
     padding-top: 30px;
     z-index: 15;
-    background: hsl(210, 33.33%, 94.0%);
+    background: hsl(210, 33.33%, 94%);
     border: 1px solid #ccc;
     border-radius: 5px;
     user-select: none;
@@ -172,13 +173,17 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    #account.active {
-      color: #333;
+    #account_menu {
+      background: #384047;
+      border-color: #52667a;
     }
 
-    #account_menu {
-      background: hsl(210, 33.33%, 94.0%);
-      border-color: #ccc;
+    li.link a {
+      color: #ccc;
+    }
+
+    #account_menu :global(li:not(.link) + li.link) {
+      border-top-color: #52667a;
     }
   }
 </style>

--- a/src/components/AccountMenuButton.svelte
+++ b/src/components/AccountMenuButton.svelte
@@ -1,17 +1,27 @@
 <script lang="ts">
   type Props = {
-    title?: string,
-    label: string,
-    showCheckmark?: boolean,
-    onclick: (e: Event) => void
-  }
+    title?: string;
+    label: string;
+    showCheckmark?: boolean;
+    onclick: (e: Event) => void;
+  };
 
-  let { title = undefined, label, showCheckmark = false, onclick }: Props = $props();
+  let {
+    title = undefined,
+    label,
+    showCheckmark = false,
+    onclick,
+  }: Props = $props();
 </script>
 
-<li><a class="button" href="#" {onclick} {title}>
-  {#if showCheckmark} <span class="check">✓</span> {/if} {label}
-</a></li>
+<li>
+  <a class="button" href="#" {onclick} {title}>
+    {#if showCheckmark}
+      <span class="check">✓</span>
+    {/if}
+    {label}
+  </a>
+</li>
 
 <style>
   li .button {
@@ -32,13 +42,19 @@
 
   @media (prefers-color-scheme: dark) {
     li .button {
-      color: #333;
-      border-color: #bbb;
-      background-color: hsla(210, 100%, 4%, 0.12);
+      color: #ccc;
+      border-color: #52667a;
+      background-color: hsla(210, 100%, 80%, 0.08);
     }
-
     li .button:hover {
-      background-color: hsla(210, 100%, 4%, 0.2);
+      color: #fff;
+      border-color: #6a80a0;
+      background-color: hsla(210, 100%, 80%, 0.15);
+    }
+    li .button:active {
+      color: #fff;
+      border-color: #3a5068;
+      background-color: hsla(210, 100%, 80%, 0.05);
     }
   }
 </style>

--- a/src/components/DialogPanel.svelte
+++ b/src/components/DialogPanel.svelte
@@ -4,9 +4,14 @@
     id?: string;
     class?: string;
     onClose?: () => void;
-  }
+  };
 
-  let { children, onClose = undefined, id = undefined, ...props }: Props = $props();
+  let {
+    children,
+    onClose = undefined,
+    id = undefined,
+    ...props
+  }: Props = $props();
 
   function onclick(e: Event) {
     // close the dialog (if it's closable) on click on the overlay, but not on anything inside
@@ -62,7 +67,7 @@
 
     .close:hover {
       color: hsl(210, 100%, 65%);
-      opacity: 1.0;
+      opacity: 1;
     }
 
     p {
@@ -78,7 +83,8 @@
       padding-right: 10px;
     }
 
-    input[type="text"], input[type="password"] {
+    input[type="text"],
+    input[type="password"] {
       width: 200px;
       font-size: 11pt;
       border: 1px solid #d6d6d6;
@@ -108,6 +114,25 @@
     input[type="submit"]:active {
       background-color: hsl(210, 100%, 87%);
       border: 1px solid hsl(210, 90%, 80%);
+    }
+    @media (prefers-color-scheme: dark) {
+      form {
+        background-color: #384047;
+        border-color: #52667a;
+      }
+      input[type="submit"] {
+        background-color: #2a5a8a;
+        border-color: #3a6a9a;
+        color: white;
+      }
+      input[type="submit"]:hover {
+        background-color: #3a6a9a;
+        border-color: #4a7aaa;
+      }
+      input[type="submit"]:active {
+        background-color: #1a4a7a;
+        border-color: #2a5a8a;
+      }
     }
   }
 </style>


### PR DESCRIPTION
Fixes #5, and generally fixes dark mode. 
## What I did
Fixed dark mode. Modified the account menu, its buttons, and the dialog panel to have correct `(prefers-color-scheme: dark)` media queries. Buttons now also have proper `:active` and `:hover` states where they might not have had any. Let me know if you want different colors!

<img width="167" height="291" alt="image" src="https://github.com/user-attachments/assets/b3102db1-7bc4-423b-bac0-d5e310f31aa2" />
<img width="300" height="277" alt="image" src="https://github.com/user-attachments/assets/5a60d02e-104f-47ad-8302-9f4806c6cea1" />
<img width="455" height="381" alt="image" src="https://github.com/user-attachments/assets/6f02d8dc-1bfe-4bd0-b802-2839f91a2150" />


## Test plan
- [x] Check login dialog
- [x] Check account menu and buttons
- [x] Check infohazards dialog box (if you don't see it, delete the entry from your localStorage)
- [x] Check `:hover` and `:active` states for the buttons

(I haven't checked WCAG standards but it's at least easy to read now.)